### PR TITLE
refactor: use libcbor instead of cbor-ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ sudo: false
 language: ruby
 cache: bundler
 
+os:
+  - linux
+  - osx
+
 rvm:
   - ruby-head
   - 2.6.5
@@ -15,7 +19,9 @@ gemfile:
   - gemfiles/openssl_2_0.gemfile
   - gemfiles/openssl_default.gemfile
 
-before_install: gem install bundler -v '~> 2.0'
+before_install:
+  - gem install bundler -v '~> 2.0'
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./script/setup-osx; else sudo ./script/setup-linux; fi
 
 matrix:
   fast_finish: true

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in cose.gemspec
 gemspec
+
+# TODO: Remove this once libcbor gem is released with
+# https://github.com/PJK/libcbor-ruby/pull/10
+gem "libcbor", github: "PJK/libcbor-ruby"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,21 @@ Ruby implementation of RFC [8152](https://tools.ietf.org/html/rfc8152) CBOR Obje
 [![Gem](https://img.shields.io/gem/v/cose.svg?style=flat-square)](https://rubygems.org/gems/cose)
 [![Travis](https://img.shields.io/travis/cedarcode/cose-ruby.svg?style=flat-square)](https://travis-ci.org/cedarcode/cose-ruby)
 
+## Prerequisites
+
+### OSX
+
+```
+brew tap pjk/libcbor
+brew install libcbor
+```
+
+### Linux (APT)
+
+```
+apt-get install libcbor-dev
+```
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/cose.gemspec
+++ b/cose.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3"
 
-  spec.add_dependency "cbor", "~> 0.5.9"
+  spec.add_dependency "libcbor", "~> 0.1.0"
 
   spec.add_development_dependency "appraisal", "~> 2.2.0"
   spec.add_development_dependency "bundler", ">= 1.17", "< 3"

--- a/gemfiles/openssl_2_0.gemfile
+++ b/gemfiles/openssl_2_0.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "libcbor", git: "https://github.com/PJK/libcbor-ruby"
 gem "openssl", "~> 2.0.0"
 
 gemspec path: "../"

--- a/gemfiles/openssl_2_1.gemfile
+++ b/gemfiles/openssl_2_1.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "libcbor", git: "https://github.com/PJK/libcbor-ruby"
 gem "openssl", "~> 2.1.0"
 
 gemspec path: "../"

--- a/gemfiles/openssl_default.gemfile
+++ b/gemfiles/openssl_default.gemfile
@@ -2,4 +2,6 @@
 
 source "https://rubygems.org"
 
+gem "libcbor", git: "https://github.com/PJK/libcbor-ruby"
+
 gemspec path: "../"

--- a/gemfiles/openssl_head.gemfile
+++ b/gemfiles/openssl_head.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "libcbor", git: "https://github.com/PJK/libcbor-ruby"
 gem "openssl", git: "https://github.com/ruby/openssl"
 
 gemspec path: "../"

--- a/lib/cbor.rb
+++ b/lib/cbor.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require "libcbor/all"

--- a/lib/cose/security_message.rb
+++ b/lib/cose/security_message.rb
@@ -14,12 +14,12 @@ module COSE
     def self.deserialize(cbor)
       decoded = CBOR.decode(cbor)
 
-      if decoded.is_a?(CBOR::Tagged)
-        if respond_to?(:tag) && tag != decoded.tag
+      if decoded.is_a?(CBOR::Tag)
+        if respond_to?(:tag) && tag != decoded.value
           raise(COSE::Error, "Invalid CBOR tag")
         end
 
-        decoded = decoded.value
+        decoded = decoded.item
       end
 
       from_array(decoded)

--- a/script/setup-linux
+++ b/script/setup-linux
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -x
+
+if ! apt-cache show libcbor-dev >> /dev/null; then
+  add-apt-repository ppa:yubico/stable -y
+  apt-get update -q
+fi
+
+apt-get install libcbor-dev -y

--- a/script/setup-osx
+++ b/script/setup-osx
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -x
+
+brew tap pjk/libcbor
+brew install libcbor

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ RSpec.configure do |config|
 end
 
 def create_security_message(protected_headers, unprotected_headers, *args, cbor_tag: 0)
-  CBOR::Tagged.new(cbor_tag, [CBOR.encode(protected_headers), unprotected_headers, *args]).to_cbor
+  CBOR::Tag.new(cbor_tag, [CBOR.encode(protected_headers), unprotected_headers, *args]).to_cbor
 end
 
 def wg_examples(relative_glob)


### PR DESCRIPTION
This is a re-opening of https://github.com/cedarcode/cose-ruby/pull/10 as "Draft".

Pending:

- [x] Auto bytestring detection in `libcbor-ruby` (fixed in https://github.com/PJK/libcbor-ruby/pull/10)
- [ ] Passing tests (waiting fixes for https://github.com/PJK/libcbor-ruby/issues/11 and https://github.com/PJK/libcbor-ruby/issues/12)
- [ ] Point to a released version of `libcbor-ruby`