### PR TITLE
ci: test against ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache: bundler
 
 rvm:
   - ruby-head
+  - 2.7.0-preview3
   - 2.6.5
   - 2.5.7
   - 2.4.9


### PR DESCRIPTION
ruby 2.7 is going to be released Dec 25th 2019.