### PR TITLE
Add EdDSA support

### DIFF
--- a/lib/cose/algorithm.rb
+++ b/lib/cose/algorithm.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "cose/algorithm/ecdsa"
+require "cose/algorithm/eddsa"
 require "cose/algorithm/hmac"
 require "cose/algorithm/rsa_pss"
 
@@ -30,6 +31,7 @@ module COSE
     register(ECDSA.new(-35, "ES384", hash_function: "SHA384", curve_name: "P-384"))
     register(ECDSA.new(-36, "ES512", hash_function: "SHA512", curve_name: "P-521"))
     register(ECDSA.new(-47, "ES256K", hash_function: "SHA256", curve_name: "secp256k1"))
+    register(EdDSA.new(-8, "EdDSA"))
     register(RSAPSS.new(-37, "PS256", hash_function: "SHA256", salt_length: 32))
     register(RSAPSS.new(-38, "PS384", hash_function: "SHA384", salt_length: 48))
     register(RSAPSS.new(-39, "PS512", hash_function: "SHA512", salt_length: 64))

--- a/lib/cose/algorithm/eddsa.rb
+++ b/lib/cose/algorithm/eddsa.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "cose/algorithm/signature_algorithm"
+require "cose/error"
+require "cose/key/okp"
+require "openssl"
+
+module COSE
+  module Algorithm
+    class EdDSA < SignatureAlgorithm
+      private
+
+      def valid_key?(key)
+        cose_key = to_cose_key(key)
+
+        cose_key.is_a?(COSE::Key::OKP) && (!cose_key.alg || cose_key.alg == id)
+      end
+
+      def to_pkey(key)
+        case key
+        when COSE::Key::OKP
+          key.to_pkey
+        when OpenSSL::PKey::PKey
+          key
+        else
+          raise(COSE::Error, "Incompatible key for algorithm")
+        end
+      end
+
+      def valid_signature?(key, signature, verification_data)
+        pkey = to_pkey(key)
+
+        begin
+          pkey.verify(nil, signature, verification_data)
+        rescue OpenSSL::PKey::PKeyError
+          false
+        end
+      end
+    end
+  end
+end

--- a/lib/cose/key.rb
+++ b/lib/cose/key.rb
@@ -24,6 +24,8 @@ module COSE
         COSE::Key::EC2.from_pkey(pkey)
       when OpenSSL::PKey::RSA
         COSE::Key::RSA.from_pkey(pkey)
+      when OpenSSL::PKey::PKey
+        COSE::Key::OKP.from_pkey(pkey)
       else
         raise "Unsupported #{pkey.class} object"
       end

--- a/lib/cose/key/curve.rb
+++ b/lib/cose/key/curve.rb
@@ -32,4 +32,6 @@ end
 COSE::Key::Curve.register(1, "P-256", "prime256v1")
 COSE::Key::Curve.register(2, "P-384", "secp384r1")
 COSE::Key::Curve.register(3, "P-521", "secp521r1")
+COSE::Key::Curve.register(6, "Ed25519", "ED25519")
+COSE::Key::Curve.register(7, "Ed448", "ED448")
 COSE::Key::Curve.register(8, "secp256k1", "secp256k1")

--- a/lib/cose/key/okp.rb
+++ b/lib/cose/key/okp.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "cose/key/curve"
 require "cose/key/curve_key"
 require "openssl"
 
@@ -14,8 +15,55 @@ module COSE
         end
       end
 
+      def self.from_pkey(pkey)
+        curve = Curve.by_pkey_name(pkey.oid) || raise("Unsupported edwards curve #{pkey.oid}")
+        attributes = { crv: curve.id }
+
+        asymmetric_key = pkey.public_to_der
+        public_key_bit_string = OpenSSL::ASN1.decode(asymmetric_key).value.last.value
+        attributes[:x] = public_key_bit_string
+        begin
+          asymmetric_key = pkey.private_to_der
+          private_key = OpenSSL::ASN1.decode(asymmetric_key).value.last.value
+          curve_private_key = OpenSSL::ASN1.decode(private_key).value
+          attributes[:d] = curve_private_key
+        rescue OpenSSL::PKey::PKeyError
+          # work around lack of https://github.com/ruby/openssl/pull/527, otherwise raises this error
+          # with message 'i2d_PKCS8PrivateKey_bio: error converting private key' for public keys
+          nil
+        end
+
+        new(**attributes)
+      end
+
       def map
         super.merge(LABEL_KTY => KTY_OKP)
+      end
+
+      def to_pkey
+        if curve
+          private_key_algo = OpenSSL::ASN1::Sequence.new(
+            [OpenSSL::ASN1::ObjectId.new(curve.pkey_name)]
+          )
+          seq = if d
+                  version = OpenSSL::ASN1::Integer.new(0)
+                  curve_private_key = OpenSSL::ASN1::OctetString.new(d).to_der
+                  private_key = OpenSSL::ASN1::OctetString.new(curve_private_key)
+                  [version, private_key_algo, private_key]
+                else
+                  public_key = OpenSSL::ASN1::BitString.new(x)
+                  [private_key_algo, public_key]
+                end
+
+          asymmetric_key = OpenSSL::ASN1::Sequence.new(seq)
+          OpenSSL::PKey.read(asymmetric_key.to_der)
+        else
+          raise "Unsupported curve #{crv}"
+        end
+      end
+
+      def curve
+        Curve.find(crv)
       end
     end
   end

--- a/spec/cose/key/okp_spec.rb
+++ b/spec/cose/key/okp_spec.rb
@@ -38,6 +38,50 @@ RSpec.describe COSE::Key::OKP do
     end
   end
 
+  context "#to_pkey" do
+    if curve_25519_supported?
+      it "works for an Ed25519 private key" do
+        original_pkey = OpenSSL::PKey.generate_key("ED25519")
+        pkey = COSE::Key::OKP.from_pkey(original_pkey).to_pkey
+
+        expect(pkey).to be_a(OpenSSL::PKey::PKey)
+        expect(pkey.oid).to eq("ED25519")
+        expect(pkey.public_to_der).to eq(original_pkey.public_to_der)
+        expect(pkey.private_to_der).to eq(original_pkey.private_to_der)
+      end
+
+      it "works for an Ed25519 public key" do
+        original_pkey = OpenSSL::PKey.generate_key("ED25519")
+        public_key = OpenSSL::PKey.read(original_pkey.public_to_der)
+        pkey = COSE::Key::OKP.from_pkey(public_key).to_pkey
+
+        expect(pkey).to be_a(OpenSSL::PKey::PKey)
+        expect(pkey.oid).to eq("ED25519")
+        expect(pkey.public_to_der).to eq(original_pkey.public_to_der)
+      end
+
+      it "works for an Ed448 private key" do
+        original_pkey = OpenSSL::PKey.generate_key("ED448")
+        pkey = COSE::Key::OKP.from_pkey(original_pkey).to_pkey
+
+        expect(pkey).to be_a(OpenSSL::PKey::PKey)
+        expect(pkey.oid).to eq("ED448")
+        expect(pkey.public_to_der).to eq(original_pkey.public_to_der)
+        expect(pkey.private_to_der).to eq(original_pkey.private_to_der)
+      end
+
+      it "works for an Ed448 public key" do
+        original_pkey = OpenSSL::PKey.generate_key("ED448")
+        public_key = OpenSSL::PKey.read(original_pkey.public_to_der)
+        pkey = COSE::Key::OKP.from_pkey(public_key).to_pkey
+
+        expect(pkey).to be_a(OpenSSL::PKey::PKey)
+        expect(pkey.oid).to eq("ED448")
+        expect(pkey.public_to_der).to eq(original_pkey.public_to_der)
+      end
+    end
+  end
+
   describe ".deserialize" do
     it "works" do
       key = COSE::Key::OKP.deserialize(

--- a/spec/cose/sign1_spec.rb
+++ b/spec/cose/sign1_spec.rb
@@ -78,5 +78,29 @@ RSpec.describe "COSE::Sign1" do
         end
       end
     end
+
+    if curve_25519_supported?
+      wg_examples("eddsa-examples/eddsa-sig-*.json") do |example|
+        it "passes #{example['title']}" do
+          key_data = example["input"]["sign0"]["key"]
+
+          key = COSE::Key::OKP.new(
+            kid: key_data["kid"],
+            alg: COSE::Algorithm.by_name(example["input"]["sign0"]["alg"]).id,
+            crv: COSE::Key::Curve.by_name(key_data["crv"]).id,
+            x: hex_to_bytes(key_data["x_hex"]),
+            d: hex_to_bytes(key_data["d_hex"])
+          )
+
+          cbor = hex_to_bytes(example["output"]["cbor"])
+
+          if example["fail"]
+            expect { COSE::Sign1.deserialize(cbor).verify(key) }.to raise_error(COSE::Error)
+          else
+            expect(COSE::Sign1.deserialize(cbor).verify(key)).to be_truthy
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/cose/sign_spec.rb
+++ b/spec/cose/sign_spec.rb
@@ -87,6 +87,29 @@ RSpec.describe "COSE::Sign" do
       end
     end
 
+    if curve_25519_supported?
+      wg_examples("eddsa-examples/eddsa-0*.json") do |example|
+        it "passes #{example['title']}" do
+          key_data = example["input"]["sign"]["signers"][0]["key"]
+
+          key = COSE::Key::OKP.new(
+            kid: key_data["kid"],
+            crv: COSE::Key::Curve.by_name(key_data["crv"]).id,
+            x: hex_to_bytes(key_data["x_hex"]),
+            d: hex_to_bytes(key_data["d_hex"])
+          )
+
+          cbor = hex_to_bytes(example["output"]["cbor"])
+
+          if example["fail"]
+            expect { COSE::Sign.deserialize(cbor).verify(key) }.to raise_error(COSE::Error)
+          else
+            expect(COSE::Sign.deserialize(cbor).verify(key)).to be_truthy
+          end
+        end
+      end
+    end
+
     if rsa_pss_supported?
       wg_examples("rsa-pss-examples/*.json") do |example|
         it "passes #{example['title']}" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,11 @@ def rsa_pss_supported?
   OpenSSL::PKey::RSA.instance_methods.include?(:verify_pss)
 end
 
+def curve_25519_supported?
+  OpenSSL::OPENSSL_VERSION_NUMBER >= 0x10101000 && # >= v1.1.1
+    defined?(OpenSSL::PKey.generate_key)
+end
+
 def hex_to_bytes(hex_string)
   [hex_string].pack("H*")
 end


### PR DESCRIPTION
This relies generic pkey support currently in OpenSSL gem master, slated to be released as 3.0 (https://github.com/ruby/openssl/pull/329). Closes https://github.com/cedarcode/cose-ruby/issues/48

EdDSA in COSE is 'pure' and takes no hash: https://tools.ietf.org/html/rfc8152#section-8.2

The ASN1 structure is described in https://tools.ietf.org/html/rfc5958 and some experimentation of returned values by the OpenSSL bindings using https://lapo.it/asn1js/