### PR TITLE
Add support for OpenSSL 3.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
           - 2.5.8
           - 2.4.10
         gemfile:
+          - openssl_3_0
           - openssl_2_2
           - openssl_2_1
           - openssl_2_0

--- a/Appraisals
+++ b/Appraisals
@@ -12,5 +12,9 @@ appraise "openssl_2_0" do
   gem "openssl", "~> 2.0.0"
 end
 
+appraise "openssl_3_0" do
+  gem "openssl", "~> 3.0.0"
+end
+
 appraise "openssl_default" do
 end

--- a/lib/cose/key/rsa.rb
+++ b/lib/cose/key/rsa.rb
@@ -88,31 +88,28 @@ module COSE
       end
 
       def to_pkey
-        pkey = OpenSSL::PKey::RSA.new
-
-        if pkey.respond_to?(:set_key)
-          pkey.set_key(bn(n), bn(e), bn(d))
-        else
-          pkey.n = bn(n)
-          pkey.e = bn(e)
-          pkey.d = bn(d)
-        end
+        # PKCS#1 RSAPublicKey
+        asn1 = OpenSSL::ASN1::Sequence([
+          OpenSSL::ASN1::Integer.new(bn(n)),
+          OpenSSL::ASN1::Integer.new(bn(e)),
+        ])
+        pkey = OpenSSL::PKey::RSA.new(asn1.to_der)
 
         if private?
-          if pkey.respond_to?(:set_factors)
-            pkey.set_factors(bn(p), bn(q))
-          else
-            pkey.p = bn(p)
-            pkey.q = bn(q)
-          end
+          # PKCS#1 RSAPrivateKey
+          asn1 = OpenSSL::ASN1::Sequence([
+            OpenSSL::ASN1::Integer.new(0),
+            OpenSSL::ASN1::Integer.new(bn(n)),
+            OpenSSL::ASN1::Integer.new(bn(e)),
+            OpenSSL::ASN1::Integer.new(bn(d)),
+            OpenSSL::ASN1::Integer.new(bn(p)),
+            OpenSSL::ASN1::Integer.new(bn(q)),
+            OpenSSL::ASN1::Integer.new(bn(dp)),
+            OpenSSL::ASN1::Integer.new(bn(dq)),
+            OpenSSL::ASN1::Integer.new(bn(qinv)),
+          ])
 
-          if pkey.respond_to?(:set_crt_params)
-            pkey.set_crt_params(bn(dp), bn(dq), bn(qinv))
-          else
-            pkey.dmp1 = bn(dp)
-            pkey.dmq1 = bn(dq)
-            pkey.iqmp = bn(qinv)
-          end
+          pkey = OpenSSL::PKey::RSA.new(asn1.to_der)
         end
 
         pkey

--- a/spec/cose/key/ec2_spec.rb
+++ b/spec/cose/key/ec2_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe COSE::Key::EC2 do
 
   context "#to_pkey" do
     it "works for an EC key in the P-256 curve" do
-      original_pkey = OpenSSL::PKey::EC.new("prime256v1").generate_key
+      original_pkey = OpenSSL::PKey::EC.generate("prime256v1")
       pkey = COSE::Key::EC2.from_pkey(original_pkey).to_pkey
 
       expect(pkey).to be_a(OpenSSL::PKey::EC)
@@ -103,7 +103,7 @@ RSpec.describe COSE::Key::EC2 do
     end
 
     it "works for an EC key in the P-384 curve" do
-      original_pkey = OpenSSL::PKey::EC.new("secp384r1").generate_key
+      original_pkey = OpenSSL::PKey::EC.generate("secp384r1")
       pkey = COSE::Key::EC2.from_pkey(original_pkey).to_pkey
 
       expect(pkey).to be_a(OpenSSL::PKey::EC)
@@ -113,7 +113,7 @@ RSpec.describe COSE::Key::EC2 do
     end
 
     it "works for an EC key in the P-521 curve" do
-      original_pkey = OpenSSL::PKey::EC.new("secp521r1").generate_key
+      original_pkey = OpenSSL::PKey::EC.generate("secp521r1")
       pkey = COSE::Key::EC2.from_pkey(original_pkey).to_pkey
 
       expect(pkey).to be_a(OpenSSL::PKey::EC)
@@ -123,7 +123,7 @@ RSpec.describe COSE::Key::EC2 do
     end
 
     it "works for an EC key in the secp256k1 curve" do
-      original_pkey = OpenSSL::PKey::EC.new("secp256k1").generate_key
+      original_pkey = OpenSSL::PKey::EC.generate("secp256k1")
       pkey = COSE::Key::EC2.from_pkey(original_pkey).to_pkey
 
       expect(pkey).to be_a(OpenSSL::PKey::EC)

--- a/spec/cose/key_spec.rb
+++ b/spec/cose/key_spec.rb
@@ -7,7 +7,7 @@ require "openssl"
 RSpec.describe COSE::Key do
   describe ".serialize" do
     it "can serialize EC P-256 key" do
-      key = OpenSSL::PKey::EC.new("prime256v1").generate_key
+      key = OpenSSL::PKey::EC.generate("prime256v1")
 
       cbor = COSE::Key.serialize(key)
       map = CBOR.decode(cbor)
@@ -21,7 +21,7 @@ RSpec.describe COSE::Key do
     end
 
     it "can serialize EC P-384 key" do
-      key = OpenSSL::PKey::EC.new("secp384r1").generate_key
+      key = OpenSSL::PKey::EC.generate("secp384r1")
 
       cbor = COSE::Key.serialize(key)
       map = CBOR.decode(cbor)
@@ -35,7 +35,7 @@ RSpec.describe COSE::Key do
     end
 
     it "can serialize EC P-521 key" do
-      key = OpenSSL::PKey::EC.new("secp521r1").generate_key
+      key = OpenSSL::PKey::EC.generate("secp521r1")
 
       cbor = COSE::Key.serialize(key)
       map = CBOR.decode(cbor)


### PR DESCRIPTION
PKey objects are immutable in OpenSSL 3.0, so the `to_pkey` methods had to be rewritten.

Unfortunately, the `openssl` gem does not seem to provide a convenient way to build PKeys from individual parameters. Instead, this commits goes through ASN.1 representations of the keys, as suggested in https://github.com/ruby/openssl/issues/498#issuecomment-1065574184

As is, the PR is incomplete because of the dependency to the `openssl-signature_algorithm` which is not yet compatible with OpenSSL 3.0 (see https://github.com/cedarcode/openssl-signature_algorithm/pull/5).