### PR TITLE
Upgrade cbor to >= 0.5.9.7

### DIFF
--- a/cose.gemspec
+++ b/cose.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.4"
 
-  spec.add_dependency "cbor", "~> 0.5.9"
+  spec.add_dependency "cbor", ">= 0.5.9.7"
   spec.add_dependency "openssl-signature_algorithm", "~> 1.0"
 
   spec.add_development_dependency "appraisal", "~> 2.2.0"


### PR DESCRIPTION
cbor doesn't use semantic versioning, and had a bug which prevented installation which was fixed in 0.5.9.7: https://github.com/cabo/cbor-ruby/commits/master/

This attempts to upgrade this gem to use the later cbor versions, which it seems rubygem's isn't picking up due to the non-standard versioning scheme of cbor.