### PR TITLE
Handling COSE EC keys encoded without leading 0 bytes in coordinates.

### DIFF
--- a/spec/cose/key/ec2_spec.rb
+++ b/spec/cose/key/ec2_spec.rb
@@ -2,18 +2,9 @@
 
 require "cose/key/ec2"
 require "openssl"
-require "base64"
-require "cose/key"
 
 RSpec.describe COSE::Key::EC2 do
   describe ".new" do
-    it "tests" do
-      encoded_key='pQECAyYgASFYHynGYDi87vkqpFOep_onzrmNjPdVBthCuIua9pvBCssiWCBZnNAreTzLOVZrLcTrh6eh-v5GrdemuIS-bVvXrk7Wdw=='
-      cose_key=COSE::Key.deserialize(Base64.urlsafe_decode64(encoded_key))
-      cose_key.to_pkey
-    end
-
-
     it "validates crv presence" do
       expect { COSE::Key::EC2.new(crv: nil, x: "x".b, y: "y".b) }.to raise_error("Required crv is missing")
     end


### PR DESCRIPTION
Should address https://github.com/cedarcode/cose-ruby/issues/63

Added a unit test to cover it and ran them locally to verify it was working:
```
% bundle exec rspec spec

Randomized with seed 61233
.......................................................................................

Finished in 0.3211 seconds (files took 0.12736 seconds to load)
87 examples, 0 failures

Randomized with seed 61233
```