### PR TITLE
Update CI to always test against the latest `Ruby` patch versions available

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,20 +16,20 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 3.0.0
-          - 2.7.2
-          - 2.6.6
-          - 2.5.8
-          - 2.4.10
+          - 3.0
+          - 2.7
+          - 2.6
+          - 2.5
+          - 2.4
         gemfile:
           - openssl_3_0
           - openssl_2_2
           - openssl_2_1
           - openssl_default
         exclude:
-          - ruby: '2.4.10'
+          - ruby: '2.4'
             gemfile: openssl_3_0
-          - ruby: '2.5.8'
+          - ruby: '2.5'
             gemfile: openssl_3_0
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 3.0
+          - '3.0'
           - 2.7
           - 2.6
           - 2.5


### PR DESCRIPTION
## Summary

As tilted, not specify the patch version in the CI so we always run against the latest `Ruby` version available