### PR TITLE
Drop support for end-of-life `Ruby` versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,6 @@ jobs:
           - 3.2
           - 3.1
           - '3.0'
-          - 2.7
         gemfile:
           - openssl_3_2
           - openssl_3_1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,6 @@ jobs:
           - 2.7
           - 2.6
           - 2.5
-          - 2.4
         gemfile:
           - openssl_3_2
           - openssl_3_1
@@ -32,12 +31,6 @@ jobs:
           - openssl_2_1
           - openssl_default
         exclude:
-          - ruby: '2.4'
-            gemfile: openssl_3_0
-          - ruby: '2.4'
-            gemfile: openssl_3_1
-          - ruby: '2.4'
-            gemfile: openssl_3_2
           - ruby: '2.5'
             gemfile: openssl_3_0
           - ruby: '2.5'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,6 @@ jobs:
           - 3.1
           - '3.0'
           - 2.7
-          - 2.6
         gemfile:
           - openssl_3_2
           - openssl_3_1
@@ -29,9 +28,6 @@ jobs:
           - openssl_2_2
           - openssl_2_1
           - openssl_default
-        exclude:
-          - ruby: '2.6'
-            gemfile: openssl_3_2
 
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,6 @@ jobs:
           - 3.3
           - 3.2
           - 3.1
-          - '3.0'
         gemfile:
           - openssl_3_2
           - openssl_3_1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,6 @@ jobs:
           - '3.0'
           - 2.7
           - 2.6
-          - 2.5
         gemfile:
           - openssl_3_2
           - openssl_3_1
@@ -31,12 +30,6 @@ jobs:
           - openssl_2_1
           - openssl_default
         exclude:
-          - ruby: '2.5'
-            gemfile: openssl_3_0
-          - ruby: '2.5'
-            gemfile: openssl_3_1
-          - ruby: '2.5'
-            gemfile: openssl_3_2
           - ruby: '2.6'
             gemfile: openssl_3_2
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ inherit_mode:
     - Exclude
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 3.1
   DisabledByDefault: true
   Exclude:
     - "gemfiles/**/*"

--- a/cose.gemspec
+++ b/cose.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.4"
+  spec.required_ruby_version = ">= 3.1"
 
   spec.add_dependency "cbor", "~> 0.5.9"
   spec.add_dependency "openssl-signature_algorithm", "~> 1.0"

--- a/cose.gemspec
+++ b/cose.gemspec
@@ -39,6 +39,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "byebug", "~> 11.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.8"
-  spec.add_development_dependency "rubocop", "0.80.1"
+  spec.add_development_dependency "rubocop", "~> 1.72.2"
   spec.add_development_dependency "rubocop-performance", "~> 1.4"
 end


### PR DESCRIPTION
## Summary

This PR officially drops support for `Ruby` versions that have [reached their end of life](https://endoflife.date/ruby).

Bump `rubocop` constraint from `0.80.1` to `~> 1.72.2`

