### PR TITLE
Test against `Ruby 3.4`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - 3.4
           - 3.3
           - 3.2
           - 3.1

--- a/cose.gemspec
+++ b/cose.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "openssl-signature_algorithm", "~> 1.0"
 
   spec.add_development_dependency "appraisal", "~> 2.2.0"
+  spec.add_development_dependency "base64", "~> 0.2"
   spec.add_development_dependency "bundler", ">= 1.17", "< 3"
   spec.add_development_dependency "byebug", "~> 11.0"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
## Summary

This PR start testing `cose-ruby` against `Ruby 3.4`.

Add `base64` as a development dependency, `Ruby 3.4` no longer comes with `base64` and this library is used in the specs.