### PR TITLE
Update `CI` to run on `ubuntu-24`

### DIFF
--- a/.github/actions/install-openssl/action.yml
+++ b/.github/actions/install-openssl/action.yml
@@ -1,0 +1,36 @@
+name: Install OpenSSL
+inputs:
+  version:
+    description: 'The version of OpenSSL to install'
+    required: true
+  os:
+    description: 'The operating system to install OpenSSL on'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Cache OpenSSL library
+      id: cache-openssl
+      uses: actions/cache@v4
+      with:
+        path: ~/openssl
+        key: openssl-${{ inputs.version }}-${{ inputs.os }}
+
+    - name: Compile OpenSSL library
+      if: steps.cache-openssl.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        mkdir -p tmp/build-openssl && cd tmp/build-openssl
+        case ${{ inputs.version }} in
+        1.1.*)
+          OPENSSL_COMMIT=OpenSSL_
+          OPENSSL_COMMIT+=$(echo ${{ inputs.version  }} | sed -e 's/\./_/g')
+          git clone -b $OPENSSL_COMMIT --depth 1 https://github.com/openssl/openssl.git .
+          echo "Git commit: $(git rev-parse HEAD)"
+          ./Configure --prefix=$HOME/openssl --libdir=lib linux-x86_64
+          make depend && make -j4 && make install_sw
+          ;;
+        *)
+          echo "Don't know how to build OpenSSL ${{ inputs.version }}"
+          ;;
+        esac

--- a/.github/actions/install-ruby/action.yml
+++ b/.github/actions/install-ruby/action.yml
@@ -1,0 +1,64 @@
+name: Install Ruby
+inputs:
+  version:
+    description: 'The version of Ruby to install'
+    required: true
+  os:
+    description: 'The operating system to install Ruby on'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Cache Ruby
+      id: ruby-cache
+      uses: actions/cache@v4
+      with:
+        path: ~/rubies/ruby-${{ inputs.version }}
+        key: ruby-${{ inputs.version }}-${{ inputs.os }}-openssl-1.1.1w
+
+    - name: Install Ruby
+      if: steps.ruby-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        latest_patch=$(curl -s https://cache.ruby-lang.org/pub/ruby/${{ inputs.version }}/ \
+           | grep -oP "ruby-${{ inputs.version }}\.\d+\.tar\.xz" \
+           | grep -oP "\d+(?=\.tar\.xz)" \
+           | sort -V | tail -n 1)
+        wget https://cache.ruby-lang.org/pub/ruby/${{ inputs.version }}/ruby-${{ inputs.version }}.${latest_patch}.tar.xz
+        tar -xJvf ruby-${{ inputs.version }}.${latest_patch}.tar.xz
+        cd ruby-${{ inputs.version }}.${latest_patch}
+        ./configure --prefix=$HOME/rubies/ruby-${{ inputs.version }} --with-openssl-dir=$HOME/openssl
+        make
+        make install
+    - name: Update PATH
+      shell: bash
+      run: |
+        echo "~/rubies/ruby-${{ inputs.version }}/bin" >> $GITHUB_PATH
+    - name: Install Bundler
+      shell: bash
+      run: |
+        case ${{ inputs.version }} in
+        2.7* | 3.*)
+          echo "Skipping Bundler installation for Ruby ${{ inputs.version }}"
+          ;;
+        2.4* | 2.5* | 2.6*)
+          gem install bundler -v '~> 2.3.0'
+          ;;
+        *)
+          echo "Don't know how to install Bundler for Ruby ${{ inputs.version }}"
+          ;;
+        esac
+    - name: Cache Bundler Install
+      id: bundler-cache
+      uses: actions/cache@v4
+      env:
+        GEMFILE: ${{ env.BUNDLE_GEMFILE || 'Gemfile' }}
+      with:
+        path: ./vendor/bundle
+        key: bundler-ruby-${{ inputs.version }}-${{ inputs.os }}-${{ hashFiles(env.Gemfile, 'tpm-key_attestation.gemspec') }}
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        bundle config set --local path ../vendor/bundle
+        bundle install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,15 +78,24 @@ jobs:
     - run: rm Gemfile.lock
 
     - name: Install OpenSSL
+      if: matrix.ruby != '2.4'
       uses: ./.github/actions/install-openssl
       with:
         version: "1.1.1w"
         os: ${{ runner.os }}
 
     - name: Manually set up Ruby
+      if: matrix.ruby != '2.4'
       uses: ./.github/actions/install-ruby
       with:
         version: ${{ matrix.ruby }}
         os: ${{ runner.os }}
+
+    - name: Set up Ruby
+      if: matrix.ruby == '2.4'
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
 
     - run: bundle exec rspec

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,9 +74,19 @@ jobs:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
     - uses: actions/checkout@v2
+
     - run: rm Gemfile.lock
-    - uses: ruby/setup-ruby@v1
+
+    - name: Install OpenSSL
+      uses: ./.github/actions/install-openssl
       with:
-        ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true
+        version: "1.1.1w"
+        os: ${{ runner.os }}
+
+    - name: Manually set up Ruby
+      uses: ./.github/actions/install-ruby
+      with:
+        version: ${{ matrix.ruby }}
+        os: ${{ runner.os }}
+
     - run: bundle exec rspec

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Lint code for consistent style
         run: bundle exec rubocop -f github
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
This PR updates the CI to run on `ubuntu-24`, the latest Ubuntu image available on GitHub Actions.

It also adds the `install-ruby` and `install-openssl` actions to manually install Ruby and OpenSSL. For more context on these changes, see: https://github.com/cedarcode/tpm-key_attestation/pull/49

## Why?
The `ubuntu-20` GitHub Actions runner is being deprecated and will soon be unavailable.

More details:
https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/#ubuntu-20-image-is-closing-down