### PR TITLE
Run `Rubocop` as part of a different job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,21 @@ name: build
 on: push
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+
+      - name: Lint code for consistent style
+        run: bundle exec rubocop -f github
   test:
     runs-on: ubuntu-20.04
     strategy:
@@ -62,4 +77,4 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    - run: bundle exec rake
+    - run: bundle exec rspec

--- a/cose.gemspec
+++ b/cose.gemspec
@@ -39,6 +39,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "byebug", "~> 11.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.8"
-  spec.add_development_dependency "rubocop", "0.80.1"
+  spec.add_development_dependency "rubocop", "~> 1"
   spec.add_development_dependency "rubocop-performance", "~> 1.4"
 end


### PR DESCRIPTION
## Summary

- Bump `rubocop` constraint from `0.80.1` to `~> 1`
- Run `rubocop` in a different job against `Ruby 3.4`