### PR TITLE
Build an EC public point from a private scalar

### DIFF
--- a/lib/cose/key/ec2.rb
+++ b/lib/cose/key/ec2.rb
@@ -70,8 +70,13 @@ module COSE
       def to_pkey
         if curve
           group = OpenSSL::PKey::EC::Group.new(curve.pkey_name)
-          public_key_bn = OpenSSL::BN.new("\x04" + pad_coordinate(group, x) + pad_coordinate(group, y), 2)
-          public_key_point = OpenSSL::PKey::EC::Point.new(group, public_key_bn)
+          public_key_point = if x && y
+                               coordinates = pad_coordinate(group, x) + pad_coordinate(group, y)
+                               public_key_bn = OpenSSL::BN.new("\x04" + coordinates, 2)
+                               OpenSSL::PKey::EC::Point.new(group, public_key_bn)
+                             else
+                               group.generator.mul(OpenSSL::BN.new(d, 2))
+                             end
 
           # RFC5480 SubjectPublicKeyInfo
           asn1 = OpenSSL::ASN1::Sequence(


### PR DESCRIPTION
Derives the public point from the private scalar when an EC2 key contains d but omits x and y, allowing valid private-only COSE keys to produce an OpenSSL key.

Verified with 86 upstream examples plus focused EC2 round-trip and WebAuthn integration models.