### PR TITLE
Normalize malformed nested key errors

### DIFF
--- a/lib/cose/key.rb
+++ b/lib/cose/key.rb
@@ -53,7 +53,8 @@ module COSE
 
     def self.cbor_decode(data)
       CBOR.decode(data)
-    rescue CBOR::MalformedFormatError, EOFError, FloatDomainError, RegexpError, TypeError, URI::InvalidURIError
+    rescue CBOR::MalformedFormatError, CBOR::StackError, EOFError, FloatDomainError, RegexpError, TypeError,
+           URI::InvalidURIError
       raise COSE::MalformedKeyError, "Malformed CBOR key input"
     end
   end

--- a/lib/cose/key.rb
+++ b/lib/cose/key.rb
@@ -6,6 +6,7 @@ require "cose/key/okp"
 require "cose/key/rsa"
 require "cose/key/symmetric"
 require "openssl"
+require "uri"
 
 module COSE
   class Error < StandardError; end


### PR DESCRIPTION
Loads URI explicitly and converts deeply nested CBOR stack failures into COSE::MalformedKeyError alongside the other malformed-input exceptions.

Verified with 86 upstream examples plus focused malformed-key, WebAuthn, and Rails integration models.