### PR TITLE
Rebuild verification context for each signature

### DIFF
--- a/lib/cose/sign.rb
+++ b/lib/cose/sign.rb
@@ -39,16 +39,15 @@ module COSE
     private
 
     def verification_data(signature, external_aad = nil)
-      @verification_data ||=
-        CBOR.encode(
-          [
-            CONTEXT,
-            serialized_map(protected_headers),
-            serialized_map(signature.protected_headers),
-            external_aad || ZERO_LENGTH_BIN_STRING,
-            payload
-          ]
-        )
+      CBOR.encode(
+        [
+          CONTEXT,
+          serialized_map(protected_headers),
+          serialized_map(signature.protected_headers),
+          external_aad || ZERO_LENGTH_BIN_STRING,
+          payload
+        ]
+      )
     end
   end
 end


### PR DESCRIPTION
Builds signature verification data for the signature and external AAD supplied to each call, rather than memoizing the first context and reusing stale bytes.

Verified with 86 upstream examples plus focused multi-signature and WebAuthn verification models.