### PR TITLE
Validate the RSA key algorithm for RSA-PSS

### DIFF
--- a/lib/cose/algorithm/rsa_pss.rb
+++ b/lib/cose/algorithm/rsa_pss.rb
@@ -21,7 +21,9 @@ module COSE
       private
 
       def valid_key?(key)
-        to_cose_key(key).is_a?(COSE::Key::RSA)
+        cose_key = to_cose_key(key)
+
+        cose_key.is_a?(COSE::Key::RSA) && (!cose_key.alg || cose_key.alg == id)
       end
 
       def signature_algorithm_class


### PR DESCRIPTION
Rejects an RSA COSE key whose declared algorithm conflicts with the RSA-PSS verifier, while retaining algorithm-less compatible keys.

Verified with 86 upstream examples plus focused RSA-PSS and WebAuthn verification models.